### PR TITLE
ci: enable dependabot for pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: "daily"
 
-#  - package-ecosystem: "npm"
-#    directory: "/ui"
-#    schedule:
-#      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "daily"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Currently blocked by https://github.com/dependabot/dependabot-core/issues/9684

Should be merged after https://github.com/dependabot/dependabot-core/pull/10073