### PR TITLE
fix: add missing newline for console printer

### DIFF
--- a/internal/printer/console.go
+++ b/internal/printer/console.go
@@ -100,7 +100,7 @@ func Text(r *result.Result, options *CommonOption) error {
 	slog.Info("Report rendered")
 
 	_, err := options.Writer.Write(data)
-	_,_ := options.Write.Write([]byte{'\n'})
+	_,_ = options.Writer.Write([]byte{'\n'})
 
 	slog.Info("Report written")
 

--- a/internal/printer/console.go
+++ b/internal/printer/console.go
@@ -100,6 +100,7 @@ func Text(r *result.Result, options *CommonOption) error {
 	slog.Info("Report rendered")
 
 	_, err := options.Writer.Write(data)
+	_,_ := options.Write.Write([]byte{'\n'})
 
 	slog.Info("Report written")
 


### PR DESCRIPTION
fix #105

I checked the table demo and they use fmt.Println() and .Render() doesn't seem to have the option to add a newline, so here we go