### PR TITLE
Adjust output streams

### DIFF
--- a/cmd/gsa/command.go
+++ b/cmd/gsa/command.go
@@ -59,8 +59,8 @@ func init() {
 			NoAppSummary: true,
 		}),
 		kong.Help(func(options kong.HelpOptions, ctx *kong.Context) error {
-			utils.Must2(ctx.Stdout.Write([]byte("Usage: \n\tgsa <file> [flags]\n")))
-			utils.Must2(ctx.Stdout.Write([]byte("\tgsa <old file> <new file> [flags]\n")))
+			utils.Must2(ctx.Stderr.Write([]byte("Usage: \n\tgsa <file> [flags]\n")))
+			utils.Must2(ctx.Stderr.Write([]byte("\tgsa <old file> <new file> [flags]\n")))
 			return kong.DefaultHelpPrinter(options, ctx)
 		}),
 		kong.ExplicitGroups([]kong.Group{

--- a/cmd/gsa/entry.go
+++ b/cmd/gsa/entry.go
@@ -37,7 +37,7 @@ func entry() error {
 			return err
 		}
 	} else {
-		writer = utils.Stdout
+		writer = os.Stdout
 		if Options.Web {
 			writer = new(bytes.Buffer)
 		}

--- a/cmd/gsa/entry.go
+++ b/cmd/gsa/entry.go
@@ -37,7 +37,7 @@ func entry() error {
 			return err
 		}
 	} else {
-		writer = os.Stdout
+		writer = utils.SyncStdout
 		if Options.Web {
 			writer = new(bytes.Buffer)
 		}

--- a/internal/utils/log.go
+++ b/internal/utils/log.go
@@ -13,7 +13,7 @@ var startTime time.Time
 
 func InitLogger(level slog.Level) {
 	startTime = time.Now()
-	slog.SetDefault(slog.New(slog.NewTextHandler(Stdout, &slog.HandlerOptions{
+	slog.SetDefault(slog.New(slog.NewTextHandler(Stderr, &slog.HandlerOptions{
 		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
 			// remove time
 			if a.Key == "time" {
@@ -60,9 +60,9 @@ func (s *SyncOutput) SetOutput(output io.Writer) {
 	s.output = output
 }
 
-var Stdout = &SyncOutput{
+var Stderr = &SyncOutput{
 	Mutex:  sync.Mutex{},
 	output: os.Stderr,
 }
 
-var _ io.Writer = Stdout
+var _ io.Writer = Stderr

--- a/internal/utils/log.go
+++ b/internal/utils/log.go
@@ -13,9 +13,9 @@ var startTime time.Time
 
 func InitLogger(level slog.Level) {
 	startTime = time.Now()
-	slog.SetDefault(slog.New(slog.NewTextHandler(Stderr, &slog.HandlerOptions{
+	slog.SetDefault(slog.New(slog.NewTextHandler(SyncStderr, &slog.HandlerOptions{
 		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
-			// remove time
+			// replace time with duration
 			if a.Key == "time" {
 				return slog.Duration(slog.TimeKey, time.Since(startTime))
 			}
@@ -60,9 +60,17 @@ func (s *SyncOutput) SetOutput(output io.Writer) {
 	s.output = output
 }
 
-var Stderr = &SyncOutput{
+var SyncStdout = &SyncOutput{
+	Mutex:  sync.Mutex{},
+	output: os.Stdout,
+}
+
+var SyncStderr = &SyncOutput{
 	Mutex:  sync.Mutex{},
 	output: os.Stderr,
 }
 
-var _ io.Writer = Stderr
+var (
+	_ io.Writer = SyncStdout
+	_ io.Writer = SyncStderr
+)

--- a/internal/webui/net.go
+++ b/internal/webui/net.go
@@ -38,7 +38,7 @@ func (UpdateCacheFlag) BeforeReset(app *kong.Kong, _ kong.Vars) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(app.Stdout, "Cache updated: %s\n", p)
+	_, err = fmt.Fprintf(app.Stderr, "Cache updated: %s\n", p)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Changed outputs from Stdout to Stderr for logging and help messages.
- Ensured normal command outputs continue to be directed to Stdout.
- Updated logger to use Stderr for consistency in error and log handling.