### PR TITLE
docs: golangci-lint supports Go 1.23

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -57,8 +57,6 @@ It runs on the binaries from [Zxilly/go-testdata](https://github.com/Zxilly/go-t
 
 The project uses `golangci-lint` to lint the code.
 
-> Golangci-lint doesn't officially support `Go 1.23` at the moment. Use the preview version.
-
 ```bash
 golangci-lint run
 ```


### PR DESCRIPTION
The PR updates the "Linter" section in `DEVELOPMENT.md` by removing the statement "Golangci-lint doesn't officially support Go 1.23 at the moment." Support for Go 1.23 was added in golangci-lint [v1.60.0](https://github.com/golangci/golangci-lint/releases/tag/v1.60.0).