### PR TITLE
test: add missing resp.Body.Close()

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ run:
 
 linters:
   enable:
+    - bodyclose
     - errorlint
 #    - gci # fixme: disable for now, see https://github.com/daixiang0/gci/issues/209
     - loggercheck

--- a/internal/webui/net.go
+++ b/internal/webui/net.go
@@ -52,9 +52,9 @@ func download() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func(body io.ReadCloser) {
-		_ = body.Close()
-	}(resp.Body)
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// check status code
 	if resp.StatusCode != http.StatusOK {

--- a/internal/webui/server_test.go
+++ b/internal/webui/server_test.go
@@ -32,5 +32,6 @@ func TestHostServer(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
The PR adds missing response body closing and enables `bodyclose` linter.

The code
```go
defer func(body io.ReadCloser) {
	_ = body.Close()
}(resp.Body)
```
is simplified to
```go
defer func() {
	_ = resp.Body.Close()
}()
```
to workaround `bodyclose` false positive:
```sh
internal/webui/net.go:51:23: response body must be closed (bodyclose)
        resp, err := http.Get(BaseURL)
                             ^
```