### PR TITLE
fix: skip NOBITS sections in symbol analysis

### DIFF
--- a/internal/wrapper/elf.go
+++ b/internal/wrapper/elf.go
@@ -45,6 +45,10 @@ func (e *ElfWrapper) LoadSymbols(marker func(name string, addr uint64, size uint
 		return cmp.Compare(a.Value, b.Value)
 	})
 
+	return processElfSymbols(symbols, e.file.Sections, marker, goSCb)
+}
+
+func processElfSymbols(symbols []elf.Symbol, sections []*elf.Section, marker func(name string, addr uint64, size uint64, typ entity.AddrType), goSCb func(addr, size uint64)) error {
 	goStringBase := uint64(0)
 
 	for _, s := range symbols {
@@ -76,11 +80,14 @@ func (e *ElfWrapper) LoadSymbols(marker func(name string, addr uint64, size uint
 		}
 
 		i := int(s.Section)
-		if i < 0 || i >= len(e.file.Sections) {
+		if i < 0 || i >= len(sections) {
 			// just ignore, example: we met go.go
 			continue
 		}
-		sect := e.file.Sections[i]
+		sect := sections[i]
+		if sect.Type == elf.SHT_NOBITS {
+			continue // bss section, skip
+		}
 		var typ entity.AddrType
 		switch sect.Flags & (elf.SHF_WRITE | elf.SHF_ALLOC | elf.SHF_EXECINSTR) {
 		case elf.SHF_ALLOC | elf.SHF_EXECINSTR:

--- a/internal/wrapper/elf_test.go
+++ b/internal/wrapper/elf_test.go
@@ -6,7 +6,45 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Zxilly/go-size-analyzer/internal/entity"
 )
+
+func TestProcessElfSymbolsSkipsNoBitsSection(t *testing.T) {
+	bssSect := &elf.Section{}
+	bssSect.SectionHeader = elf.SectionHeader{
+		Name:  ".bss",
+		Type:  elf.SHT_NOBITS,
+		Flags: elf.SHF_ALLOC | elf.SHF_WRITE,
+		Addr:  0x1000,
+		Size:  1 << 25,
+	}
+	dataSect := &elf.Section{}
+	dataSect.SectionHeader = elf.SectionHeader{
+		Name:  ".rodata",
+		Type:  elf.SHT_PROGBITS,
+		Flags: elf.SHF_ALLOC,
+		Addr:  0x2000,
+		Size:  16,
+	}
+
+	sections := []*elf.Section{bssSect, dataSect}
+
+	var marked []string
+	marker := func(name string, _ uint64, _ uint64, _ entity.AddrType) {
+		marked = append(marked, name)
+	}
+
+	syms := []elf.Symbol{
+		{Name: "main.a", Value: 0x1000, Size: 1 << 25, Section: 0},
+		{Name: "main.b", Value: 0x2000, Size: 16, Section: 1},
+	}
+
+	err := processElfSymbols(syms, sections, marker, func(_ uint64, _ uint64) {})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"main.b"}, marked, "bss symbol should be skipped")
+}
 
 func TestGoArchReturnsExpectedArchitectures(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Array symbols in the .bss section don't actually occupy binary space but were being counted anyway. Fixed by skipping NOBITS sections when processing symbols. Also extracted the symbol processing logic into a separate function for better testability and added a test case to verify the behavior.

Fixes #522