### PR TITLE
Update gore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
-	github.com/ZxillyFork/gore v0.0.0-20260517104207-c177b8d9fc9c
+	github.com/ZxillyFork/gore v0.0.0-20260708092438-7895e61dd909
 	github.com/ZxillyFork/gosym v0.0.0-20240510024817-deed2b882525
 	github.com/ZxillyFork/trie v0.0.0-20240512061834-f75150731646
 	github.com/ZxillyFork/wazero v0.0.0-20260213135451-912d95480a5c
@@ -28,7 +28,7 @@ require (
 	github.com/puzpuzpuz/xsync/v4 v4.5.0
 	github.com/samber/lo v1.53.0
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/arch v0.27.0
+	golang.org/x/arch v0.29.0
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a
 	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/puzpuzpuz/xsync/v4 v4.5.0
 	github.com/samber/lo v1.53.0
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/arch v0.29.0
+	golang.org/x/arch v0.27.0
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a
 	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
 charm.land/lipgloss/v2 v2.0.5/go.mod h1:9oqhxt4yxIMe6q5A4kHr44DremZk7J9UNh74GlWa5nc=
 github.com/ZxillyFork/gore v0.0.0-20260517104207-c177b8d9fc9c h1:X6MH3s90kcd9oL/q+QSvbx0zkENgbH3a8RbenM8cG1I=
 github.com/ZxillyFork/gore v0.0.0-20260517104207-c177b8d9fc9c/go.mod h1:I0Y7VIJq/56APMh8okdsvzhQBpuow+qTatIJ4KxEBCg=
+github.com/ZxillyFork/gore v0.0.0-20260708092438-7895e61dd909 h1:voSkxY4I2UbRCUoQYJcuNZJSuBoZoQdvCKk7K7d4Hcs=
+github.com/ZxillyFork/gore v0.0.0-20260708092438-7895e61dd909/go.mod h1:I0Y7VIJq/56APMh8okdsvzhQBpuow+qTatIJ4KxEBCg=
 github.com/ZxillyFork/gosym v0.0.0-20240510024817-deed2b882525 h1:JtN7QBnRxeyMvDJjVdfjhGHL/msqqapHMG5jPVYh32A=
 github.com/ZxillyFork/gosym v0.0.0-20240510024817-deed2b882525/go.mod h1:AC2xDL/KBa60pBB/m0zRCDCGvzLrMkmW/aY0q+uThFE=
 github.com/ZxillyFork/trie v0.0.0-20240512061834-f75150731646 h1:Mkm17zXN+CiAXdV9/7mdCUGuEzlUNu73mB6En++kUkE=
@@ -128,6 +130,8 @@ github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 golang.org/x/arch v0.27.0 h1:0WNVcR8u9yFz8j5FvdHpgwNp3FS5U4guYdzHwEiGjoU=
 golang.org/x/arch v0.27.0/go.mod h1:0X+GdSIP+kL5wPmpK7sdkEVTt2XoYP0cSjQSbZBwOi8=
+golang.org/x/arch v0.29.0 h1:8sSET5wB0+exBm0FGmOtdHMqjlRdV2DRD3/IV6OZgho=
+golang.org/x/arch v0.29.0/go.mod h1:0X+GdSIP+kL5wPmpK7sdkEVTt2XoYP0cSjQSbZBwOi8=
 golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a h1:+3jdDGGB8NGb1Zktc737jlt3/A5f6UlwSzmvqUuufxw=
 golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
 charm.land/lipgloss/v2 v2.0.5/go.mod h1:9oqhxt4yxIMe6q5A4kHr44DremZk7J9UNh74GlWa5nc=
-github.com/ZxillyFork/gore v0.0.0-20260517104207-c177b8d9fc9c h1:X6MH3s90kcd9oL/q+QSvbx0zkENgbH3a8RbenM8cG1I=
-github.com/ZxillyFork/gore v0.0.0-20260517104207-c177b8d9fc9c/go.mod h1:I0Y7VIJq/56APMh8okdsvzhQBpuow+qTatIJ4KxEBCg=
 github.com/ZxillyFork/gore v0.0.0-20260708092438-7895e61dd909 h1:voSkxY4I2UbRCUoQYJcuNZJSuBoZoQdvCKk7K7d4Hcs=
 github.com/ZxillyFork/gore v0.0.0-20260708092438-7895e61dd909/go.mod h1:I0Y7VIJq/56APMh8okdsvzhQBpuow+qTatIJ4KxEBCg=
 github.com/ZxillyFork/gosym v0.0.0-20240510024817-deed2b882525 h1:JtN7QBnRxeyMvDJjVdfjhGHL/msqqapHMG5jPVYh32A=
@@ -130,8 +128,6 @@ github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 golang.org/x/arch v0.27.0 h1:0WNVcR8u9yFz8j5FvdHpgwNp3FS5U4guYdzHwEiGjoU=
 golang.org/x/arch v0.27.0/go.mod h1:0X+GdSIP+kL5wPmpK7sdkEVTt2XoYP0cSjQSbZBwOi8=
-golang.org/x/arch v0.29.0 h1:8sSET5wB0+exBm0FGmOtdHMqjlRdV2DRD3/IV6OZgho=
-golang.org/x/arch v0.29.0/go.mod h1:0X+GdSIP+kL5wPmpK7sdkEVTt2XoYP0cSjQSbZBwOi8=
 golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a h1:+3jdDGGB8NGb1Zktc737jlt3/A5f6UlwSzmvqUuufxw=
 golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=


### PR DESCRIPTION
With latest `go-size-analyzer` I'm getting the following error on a binary built with Go 1.26.5:

```
time=528.478417ms level=ERROR msg="Fatal error: analyze <binary_path>: type analysis get types: failed to get types data section: getting module data section failed: section does not exist"
```

I believe the issue is that gsa doesn't detect the correct Go version, because the currently pinned `gore` doesn't know about Go 1.26.5. 

Updating `gore` pulls in https://github.com/ZxillyFork/gore/commit/7895e61dd909afd9c9b31389eec6cd1743a96a20 which fixes the error.