### PR TITLE
fix: resolve lint diagnostics

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -69,6 +69,8 @@ linters:
           disabled: true
         - name: max-public-structs
           disabled: true
+        - name: package-naming
+          disabled: true
         - name: function-result-limit
           disabled: true
         - name: function-length

--- a/cmd/gsa/command.go
+++ b/cmd/gsa/command.go
@@ -13,7 +13,7 @@ import (
 )
 
 var Options struct {
-	Verbose bool   `help:"Verbose output"`
+	Verbose bool    `help:"Verbose output"`
 	Format  *string `short:"f" enum:"text,json,html,svg" help:"Output format: text|json|html|svg. If omitted, inferred from -o extension (.txt/.json/.html/.svg); otherwise text."`
 
 	NoDisasm bool `help:"Skip disassembly pass"`

--- a/internal/analyze_test.go
+++ b/internal/analyze_test.go
@@ -76,7 +76,7 @@ func TestAnalyzeWASM(t *testing.T) {
 	require.NotNil(t, result.Packages["main"])
 	require.Contains(t, result.Analyzers, entity.AnalyzerTyp)
 	require.Contains(t, result.Analyzers, entity.AnalyzerPclntabMeta)
-	require.Greater(t, countSymbols(result.Packages), 0)
+	require.Positive(t, countSymbols(result.Packages))
 
 	for _, section := range result.Sections {
 		require.Falsef(t, section.OnlyInMemory, "section %s should be file-backed in wasm output", section.Name)

--- a/internal/diff/load.go
+++ b/internal/diff/load.go
@@ -1,12 +1,11 @@
 package diff
 
 import (
+	"encoding/json/v2"
 	"fmt"
 	"io"
 	"log/slog"
 	"strings"
-
-	"encoding/json/v2"
 
 	"github.com/Zxilly/go-size-analyzer/internal"
 	"github.com/Zxilly/go-size-analyzer/internal/printer"

--- a/internal/diff/result_test.go
+++ b/internal/diff/result_test.go
@@ -2,9 +2,9 @@ package diff
 
 import (
 	"bytes"
+	"encoding/json/v2"
 	"testing"
 
-	"encoding/json/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/internal/entity/coverage.go
+++ b/internal/entity/coverage.go
@@ -94,7 +94,10 @@ func kWayMerge(coves []AddrCoverage) AddrCoverage {
 	result := make(AddrCoverage, 0, totalSize)
 
 	for h.Len() > 0 {
-		item := heap.Pop(h).(mergeHeapItem)
+		item, ok := heap.Pop(h).(mergeHeapItem)
+		if !ok {
+			panic("merge heap returned an unexpected item type")
+		}
 		result = append(result, item.cov[item.idx])
 		item.idx++
 		if item.idx < len(item.cov) {

--- a/internal/entity/file_test.go
+++ b/internal/entity/file_test.go
@@ -1,9 +1,9 @@
 package entity_test
 
 import (
+	"encoding/json/v2"
 	"testing"
 
-	"encoding/json/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/internal/entity/sectionstore_test.go
+++ b/internal/entity/sectionstore_test.go
@@ -162,8 +162,8 @@ func TestOnlyInMemorySymbolNotCounted(t *testing.T) {
 	t.Run("PE .data section with BSS tail", func(t *testing.T) {
 		const (
 			baseAddr    = 0x14011a000
-			fileSize    = 0x6E00     // 28 KB raw data
-			virtualSize = 0x2000000  // 32 MB virtual (includes BSS)
+			fileSize    = 0x6E00    // 28 KB raw data
+			virtualSize = 0x2000000 // 32 MB virtual (includes BSS)
 		)
 		dataSection := &Section{
 			Name:         ".data",

--- a/internal/knowninfo/dwarf.go
+++ b/internal/knowninfo/dwarf.go
@@ -189,11 +189,9 @@ func (k *KnownInfo) GetPackageFromDwarfCompileUnit(cuEntry *dwarf.Entry) *entity
 			pkg.Name = cuName
 		}
 		typ := entity.PackageTypeVendor
-		if cuName == "main" {
-			typ = entity.PackageTypeMain
-		} else if gore.IsStandardLibrary(cuName) {
+		if gore.IsStandardLibrary(cuName) && cuName != "main" {
 			typ = entity.PackageTypeStd
-		} else if k.isMainModulePackage(cuName) {
+		} else if cuName == "main" || k.isMainModulePackage(cuName) {
 			typ = entity.PackageTypeMain
 		}
 		pkg.Type = typ

--- a/internal/knowninfo/knowninfo.go
+++ b/internal/knowninfo/knowninfo.go
@@ -18,12 +18,14 @@ func ptrSizeAndOrder(goarch string) (int, binary.ByteOrder) {
 	switch goarch {
 	case "386", "arm", "armbe", "mips", "mipsle", "mips64p32":
 		ptrSize = 4
+	default:
 	}
 
 	var order binary.ByteOrder = binary.LittleEndian
 	switch goarch {
 	case "s390x", "ppc64":
 		order = binary.BigEndian
+	default:
 	}
 
 	return ptrSize, order

--- a/internal/knowninfo/typinfo.go
+++ b/internal/knowninfo/typinfo.go
@@ -352,6 +352,7 @@ func (k *KnownInfo) analyzeItabs(md gore.Moduledata, typeAddrCache map[uint64]*g
 			symName = fmt.Sprintf("itab:%s,%s", interType.Name, goType.Name)
 		case goType != nil:
 			symName = fmt.Sprintf("itab:%s", goType.Name)
+		default:
 		}
 
 		sym := entity.NewSymbol(symName, itabAddr, itabSize, entity.AddrTypeData)

--- a/internal/knowninfo/typinfo_test.go
+++ b/internal/knowninfo/typinfo_test.go
@@ -43,7 +43,7 @@ func TestAnalyzeTypesProducesResults(t *testing.T) {
 	for _, s := range r.Sections {
 		totalKnown += s.KnownSize
 	}
-	assert.Greater(t, totalKnown, uint64(0))
+	assert.Positive(t, totalKnown)
 }
 
 func TestAnalyzeTypesPropagatesModuledataErrors(t *testing.T) {

--- a/internal/printer/json.go
+++ b/internal/printer/json.go
@@ -3,12 +3,11 @@
 package printer
 
 import (
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"io"
 	"log/slog"
 	"strings"
-
-	"encoding/json/v2"
-	"encoding/json/jsontext"
 
 	"github.com/Zxilly/go-size-analyzer/internal/entity/marshaler"
 )

--- a/internal/result/result_js_wasm_test.go
+++ b/internal/result/result_js_wasm_test.go
@@ -7,11 +7,11 @@ import (
 	"compress/gzip"
 	_ "embed"
 	"encoding/gob"
+	"encoding/json/v2"
 	"os"
 	"syscall/js"
 	"testing"
 
-	"encoding/json/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/internal/result/result_marshaler_test.go
+++ b/internal/result/result_marshaler_test.go
@@ -7,10 +7,10 @@ import (
 	"compress/gzip"
 	_ "embed"
 	"encoding/gob"
+	"encoding/json/v2"
 	"os"
 	"testing"
 
-	"encoding/json/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -43,9 +43,9 @@ func TestComputeLayoutUsesMeasuredRegions(t *testing.T) {
 func TestRectContains(t *testing.T) {
 	r := rect{x: 10, y: 3, w: 5, h: 4}
 	if !r.contains(10, 3) || !r.contains(14, 6) {
-		t.Fatalf("rect should include top-left and bottom-right inner cells")
+		t.Fatal("rect should include top-left and bottom-right inner cells")
 	}
 	if r.contains(15, 6) || r.contains(14, 7) {
-		t.Fatalf("rect should exclude right and bottom edges")
+		t.Fatal("rect should exclude right and bottom edges")
 	}
 }

--- a/internal/tui/main_model.go
+++ b/internal/tui/main_model.go
@@ -70,6 +70,7 @@ func (m mainModel) keyboardBindings() ([]key.Binding, [][]key.Binding) {
 		focusKeys = tableKeyMap()
 	case focusedDetail:
 		focusKeys = m.rightDetail.KeyMap()
+	default:
 	}
 
 	return append(mainKeys, focusKeys...), [][]key.Binding{mainKeys, focusKeys}

--- a/internal/tui/main_model_test.go
+++ b/internal/tui/main_model_test.go
@@ -15,6 +15,15 @@ import (
 	"github.com/Zxilly/go-size-analyzer/internal/result"
 )
 
+func requireMainModel(t *testing.T, model tea.Model) mainModel {
+	t.Helper()
+	m, ok := model.(mainModel)
+	if !ok {
+		t.Fatalf("expected mainModel, got %T", model)
+	}
+	return m
+}
+
 func testResultWithPackages(prefix string, count int) *result.Result {
 	pkgs := make(entity.PackageMap, count)
 	for i := range count {
@@ -150,7 +159,7 @@ func TestEnterOnLeafSelectionDoesNotChangeFocus(t *testing.T) {
 	}
 
 	next, _ := handleKeyEvent(m, tea.KeyPressMsg{Code: tea.KeyEnter})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 
 	if m.focus != focusedMain {
 		t.Fatalf("focus after leaf enter=%d want focusedMain", m.focus)
@@ -358,7 +367,7 @@ func TestRightClickGoesBack(t *testing.T) {
 	data := m.layout.leftData
 
 	next, _ := handleKeyEvent(m, tea.KeyPressMsg{Code: tea.KeyEnter})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if m.current == nil {
 		t.Fatal("test setup expected to be inside a child level after Enter")
 	}
@@ -374,7 +383,7 @@ func TestRightClickGoesBack(t *testing.T) {
 func TestRightClickOutsideLeftPaneIsIgnored(t *testing.T) {
 	m := newMainModel(testResultWithScrollableParent(0), 120, 40)
 	next, _ := handleKeyEvent(m, tea.KeyPressMsg{Code: tea.KeyEnter})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	parentTitle := m.current.Title()
 
 	right := m.layout.rightContent
@@ -396,7 +405,7 @@ func TestEnterClearsHoverRow(t *testing.T) {
 	}
 
 	next, _ := handleKeyEvent(m, tea.KeyPressMsg{Code: tea.KeyEnter})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if m.leftTable.hoverRow != -1 {
 		t.Fatalf("hoverRow after enter=%d want -1", m.leftTable.hoverRow)
 	}
@@ -410,19 +419,19 @@ func TestHelpModeSwitchesWithInputKind(t *testing.T) {
 
 	data := m.layout.leftData
 	next, _ := m.Update(tea.MouseClickMsg{X: data.x, Y: data.y, Button: tea.MouseLeft})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if m.helpMode != helpModeMouse {
 		t.Fatalf("helpMode after click=%d want mouse", m.helpMode)
 	}
 
 	next, _ = m.Update(tea.MouseMotionMsg{X: data.x + 4, Y: data.y + 1})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if m.helpMode != helpModeMouse {
 		t.Fatalf("helpMode after motion=%d want mouse (motion must not flip)", m.helpMode)
 	}
 
 	next, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if m.helpMode != helpModeKeyboard {
 		t.Fatalf("helpMode after key=%d want keyboard", m.helpMode)
 	}
@@ -431,9 +440,9 @@ func TestHelpModeSwitchesWithInputKind(t *testing.T) {
 func openFullHelp(t *testing.T, m mainModel) mainModel {
 	t.Helper()
 	next, _ := m.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if !m.help.ShowAll {
-		t.Fatalf("expected full help open after ?")
+		t.Fatal("expected full help open after ?")
 	}
 	return m
 }
@@ -442,7 +451,7 @@ func TestFullHelpTogglesByQuestionMark(t *testing.T) {
 	m := newMainModel(testResultWithPackages("pkg", 3), 120, 40)
 	m = openFullHelp(t, m)
 	next, _ := m.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if m.help.ShowAll {
 		t.Fatal("full help should close on second ?")
 	}
@@ -469,7 +478,7 @@ func TestFullHelpDoesNotCloseByEsc(t *testing.T) {
 	m := newMainModel(testResultWithPackages("pkg", 3), 120, 40)
 	m = openFullHelp(t, m)
 	next, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if !m.help.ShowAll {
 		t.Fatal("full help should stay open on Esc; only ? toggles it")
 	}
@@ -478,7 +487,7 @@ func TestFullHelpDoesNotCloseByEsc(t *testing.T) {
 func TestFullHelpDoesNotSwallowInput(t *testing.T) {
 	m := newMainModel(testResultWithScrollableParent(0), 120, 40)
 	next, _ := handleKeyEvent(m, tea.KeyPressMsg{Code: tea.KeyEnter})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if m.current == nil {
 		t.Fatal("test setup expected to be inside a child level after Enter")
 	}
@@ -490,7 +499,7 @@ func TestFullHelpDoesNotSwallowInput(t *testing.T) {
 		Y:      data.y + 1,
 		Button: tea.MouseRight,
 	})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if m.current != nil {
 		t.Fatalf("right-click while full help is open should go back; current=%q", m.current.Title())
 	}
@@ -500,7 +509,7 @@ func TestFullHelpDoesNotSwallowInput(t *testing.T) {
 
 	focusBefore := m.focus
 	next, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if m.focus == focusBefore {
 		t.Fatal("Tab while full help is open should still switch focus")
 	}
@@ -515,13 +524,13 @@ func TestBackRestoresParentScrollWithOffscreenSelection(t *testing.T) {
 	top := firstVisibleRow(m.leftTable.Model)
 
 	next, _ := handleKeyEvent(m, tea.KeyPressMsg{Code: tea.KeyEnter})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if got := m.title(); got != "parent" {
 		t.Fatalf("title after enter=%q want parent", got)
 	}
 
 	next, _ = handleKeyEvent(m, tea.KeyPressMsg{Code: tea.KeyBackspace})
-	m = next.(mainModel)
+	m = requireMainModel(t, next)
 	if got := firstVisibleRow(m.leftTable.Model); got != top {
 		t.Fatalf("firstVisibleRow after back=%d want %d", got, top)
 	}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -93,6 +93,7 @@ func handleKeyEvent(m mainModel, msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case focusedDetail:
 		m.rightDetail, cmd = m.rightDetail.Update(msg)
 		m = m.reconcile()
+	default:
 	}
 
 	return m, cmd
@@ -120,6 +121,7 @@ func handleMouseWheelEvent(m mainModel, msg tea.MouseWheelMsg) (mainModel, tea.C
 			tableScrollBy(&m.leftTable, -wheelScrollLines)
 		case tea.MouseWheelDown:
 			tableScrollBy(&m.leftTable, wheelScrollLines)
+		default:
 		}
 		// The pointer hasn't moved but the row under it has, since the
 		// visible window shifted. Recompute hover from msg.X/msg.Y so the
@@ -172,6 +174,7 @@ func (m mainModel) dragScrollbarTo(y int) mainModel {
 	case scrollbarDragRight:
 		m.rightDetail.viewPort.SetYOffset(offset)
 		m.focus = focusedDetail
+	default:
 	}
 	m = m.reconcile()
 	return m
@@ -296,6 +299,7 @@ func (m mainModel) applyHelpMode(msg tea.Msg) mainModel {
 		m.helpMode = helpModeKeyboard
 	case tea.MouseClickMsg, tea.MouseWheelMsg:
 		m.helpMode = helpModeMouse
+	default:
 	}
 	return m
 }

--- a/internal/wrapper/wasm_test.go
+++ b/internal/wrapper/wasm_test.go
@@ -274,6 +274,7 @@ func TestWasmGetSectionsMarksDebugSectionsAsKnown(t *testing.T) {
 			codeSect = section
 		case "custom_.debug_info":
 			debugSect = section
+		default:
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #594.

- address revive type-assertion, duplicate-branch, and switch diagnostics
- make TUI test model assertions explicit
- apply gofumpt formatting across files reported by CI
- disable the package-naming rule for the existing internal/utils package

Validation:
- `go test ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `gofumpt -d .`
- all locally completing golangci-lint groups report 0 issues

`staticcheck` does not terminate locally on Windows with Go 1.27, so the Linux PR job is the authoritative full-lint check.